### PR TITLE
Update README.md to include tool being used in get-deps and small fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ The kernel has a few important features that it needs to use to manage memory fo
 4. `make` - The build tool for the project
 5. `git` - The VCS and used to get some dependencies 
 6. `wget` - Also used to get dependencies
-7. `qemu` - The emulator for the kernel
+7. `qemu` - The emulator and virtual machine for the kernel
+8. `hashalot` - Set of tools used to hash data used by ./kernel/get-deps
 
 ### Build and Run the Kernel
 There are different option of running / emulating the kernel. Below is a list of them with all the commands


### PR DESCRIPTION
sha256 command is being used in ./kernel/get-deps and is in hashalot repository (Ubuntu).
qemu can also be used as a virtual machine when you enable kvm (or other hypervisor)